### PR TITLE
Refactoring `readDataBase` function

### DIFF
--- a/apriori/databases/testData.txt
+++ b/apriori/databases/testData.txt
@@ -1,9 +1,9 @@
-i1,i2,i5
-i2,i4
-i2,i3
-i1,i2,i4
-i1,i3
-i2,i3
-i1,i3
-i1,i2,i3,i5
-i1,i2,i3
+i1, i2, i5
+i2, i4
+i2, i3
+i1, i2, i4
+i1, i3
+i2, i3
+i1, i3
+i1, i2, i3, i5
+i1, i2, i3

--- a/apriori/include/Apriori.h
+++ b/apriori/include/Apriori.h
@@ -1,22 +1,33 @@
 
-#ifndef APRIRIO_H_INCLUDED
-#define APRIRIO_H_INCLUDED
+#ifndef APRIORI_H_INCLUDED
+#define APRIORI_H_INCLUDED
 
 #include <string>
 #include <map>
-class Apriori {
-    public:
+#include <set>
 
-    std::map<std::string, int> readDataBase(int&);
+typedef std::set<std::string> itemset;
+
+class Apriori {
+  public:
+    Apriori(std::string dbName, float minSup)
+        : dataBaseName(dbName), minSup(minSup) {}
+
+    /* Reads initial itemsets from file.
+     * Supply table to fill by reference as 'table'
+     * Returns number of itemsets read
+     */
+    int readDataBase(std::map<std::string, int> &table);
+    
     std::map<std::string, int> scanDataBase(std::map<std::string, int>);
     std::map<std::string, int> prune(std::map<std::string, int>, float);
     std::map<std::string, int> joinItemSets(std::map<std::string, int>);
-    std::map<std::string, int> aprioriRun(std::string, float minSup);
+    std::map<std::string, int> aprioriRun();
 
-    private:
-
-    float minSupCount = 0;
-    std::string dataBaseName = "";
+  private:
+    std::string dataBaseName;
+    float minSup;
+    int minSupCount;
 };
 
 #endif

--- a/apriori/src/Apriori.cpp
+++ b/apriori/src/Apriori.cpp
@@ -5,14 +5,14 @@
 #include <vector>
 #include <algorithm>
 
-std::map<std::string, int> Apriori::readDataBase(int& count) {
-    std::map<std::string, int> collection;
-    
+int Apriori::readDataBase(std::map<std::string, int> &table) {
+    int itemsetCount = 0;
+
     std::ifstream file;
     file.open(dataBaseName);
     if(!file.is_open()) {
-        std::cout << "not open" << std::endl;
-        return collection;
+        std::cerr << "unable to open file" << std::endl;
+        return -1;
     }
 
     // Read text file one line at a time. Assumes items are delimited by a
@@ -25,19 +25,15 @@ std::map<std::string, int> Apriori::readDataBase(int& count) {
         std::string item;
         while(iss>>item) {
             item = item.substr(0, item.length()-1);
-            collection[item]++;
+            table[item]++;
         }
 
-        count++;
-    }
-
-    for(auto i : collection) {
-        std::cout << "key " << i.first << " Value " << i.second << std::endl;
+        itemsetCount++;
     }
 
     file.close();
 
-    return collection;
+    return itemsetCount;
 }
 
 std::map<std::string, int> Apriori::scanDataBase(std::map<std::string, int> collection) {
@@ -129,13 +125,16 @@ std::map<std::string, int> Apriori::joinItemSets(std::map<std::string, int> coll
     return join;
 }
 
-std::map<std::string, int> Apriori::aprioriRun(std::string db, float minSup) {
-    int transactionNum = 0;
-    dataBaseName = db;
-    std::map<std::string, int> collection = readDataBase(transactionNum);
+std::map<std::string, int> Apriori::aprioriRun() {
+    // Perform initial scan of file
+    std::map<std::string, int> collection;
+    int ret = readDataBase(collection);
+    if(ret == -1) {
+        std::cerr << "error running apriori algorithm" << std::endl;
+        return collection;
+    }
 
-
-    minSupCount = minSup * float(transactionNum); 
+    minSupCount = (int)(minSup * float(ret)); 
     //while(1) {
         /*for(auto col : collection) {
             std::cout << col.first << " and " << col.second << "\n";

--- a/apriori/src/Apriori.cpp
+++ b/apriori/src/Apriori.cpp
@@ -1,53 +1,33 @@
 #include "../include/Apriori.h"
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <vector>
 #include <algorithm>
 
 std::map<std::string, int> Apriori::readDataBase(int& count) {
     std::map<std::string, int> collection;
-    std::fstream file;
+    
+    std::ifstream file;
     file.open(dataBaseName);
-
     if(!file.is_open()) {
         std::cout << "not open" << std::endl;
+        return collection;
     }
 
+    // Read text file one line at a time. Assumes items are delimited by a
+    // comma and a space.
     std::string line;
-
-    // read the database
     while (getline (file, line)) {
-
-        while(line.size() != 0) {
-            //checks to if a ',' exist in the string line
-            int pos = line.find(",");
-
-            if(pos == -1) {
-                //',' doesn't exists so it must be at the end of the string
-                // adds to the map if the key exist already or inserts a new one
-                if(collection.find(line) != collection.end()) {
-                    collection[line] += 1;
-                } else {
-                    collection.insert(std::make_pair(line, 1));
-                }
-
-                line.clear();
-
-            } else {
-                //',' exists
-                // adds to the map if the key exist already or inserts a new one
-                std::string sub = line.substr(0, pos);
-
-                if(collection.find(sub) != collection.end()) {
-                    collection[sub] += 1;
-                } else {
-                    collection.insert(std::make_pair(sub, 1));
-                }
-                // shrinks the string down by the substring "i1, i3" -> "i3"
-                line.erase(0, sub.length()+1);
-            }
+        line += ",";
+        
+        std::istringstream iss(line);
+        std::string item;
+        while(iss>>item) {
+            item = item.substr(0, item.length()-1);
+            collection[item]++;
         }
-        //counts how many lines it reads
+
         count++;
     }
 
@@ -61,48 +41,25 @@ std::map<std::string, int> Apriori::readDataBase(int& count) {
 }
 
 std::map<std::string, int> Apriori::scanDataBase(std::map<std::string, int> collection) {
-    std::fstream file;
+    std::ifstream file;
     file.open(dataBaseName);
-
     if(!file.is_open()) {
         std::cout << "not open" << std::endl;
+        return collection;
     }
 
-    std::string line;
-
     // read the database
+    std::string line;
     while (getline (file, line)) {
-
         std::map<std::string, int> pairs;
 
-        while(line.size() != 0) {
-            //checks to if a ',' exist in the string line
-            int pos = line.find(",");
+        line += ",";
 
-            if(pos == -1) {
-                //',' doesn't exists so it must be at the end of the string
-                // adds to the map if the key exist already or inserts a new one
-                if(pairs.find(line) != pairs.end()) {
-                    pairs[line] += 1;
-                } else {
-                    pairs.insert(std::make_pair(line, 1));
-                }
-
-                line.clear();
-
-            } else {
-                //',' exists
-                // adds to the map if the key exist already or inserts a new one
-                std::string sub = line.substr(0, pos);
-
-                if(pairs.find(sub) != pairs.end()) {
-                    pairs[sub] += 1;
-                } else {
-                    pairs.insert(std::make_pair(sub, 1));
-                }
-                // shrinks the string down by the substring "i1, i3" -> "i3"
-                line.erase(0, sub.length()+1);
-            }
+        std::istringstream iss(line);
+        std::string item;
+        while(iss>>item) {
+            item = item.substr(0, item.length()-1);
+            pairs[item]++;
         }
 
         for(auto it = collection.begin(); it != collection.end(); it++) {

--- a/apriori/src/main.cpp
+++ b/apriori/src/main.cpp
@@ -2,6 +2,11 @@
 #include <string>
 #include "../include/Apriori.h"
 
+/*
+ * Usage:
+ * ./apriori <filename>
+ */
+
 int main(int argc, char* argv[]) {
     if(argc < 2) {
         std::cerr << "no filename provided" << std::endl;
@@ -10,7 +15,7 @@ int main(int argc, char* argv[]) {
 
     std::string filename = argv[1];
 
-    Apriori a;
-    a.aprioriRun(filename, 0.22);
+    Apriori a(filename, 0.22);
+    a.aprioriRun();
     return 0;
 }


### PR DESCRIPTION
Small adjustments to reading from disk.

- Constructor function should be used to initialize values.
- `minSupCount` should be an integer value for later comparing if the number of occurrences meets or exceeds this value.
- Assuming our datasets will be comma + space delimited we can use stringstream to shorten the parsing implementation.
- `readDataBase()` should return the count instead of passing by reference. Then the map should be passed by reference. Less copying happening this way.
- added error handling for bad filenames
 